### PR TITLE
Remove duplicate function definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,11 +3,7 @@
 /** A file-like object of immutable, raw data. Blobs represent data that isn't necessarily in a JavaScript-native format. The File interface is based on Blob, inheriting blob functionality and expanding it to support files on the user's system. */
 declare interface FetchBlob extends Blob {
 	[Symbol.toStringTag]: 'Blob';
-	stream: () => ReadableStream;
-	text: () => Promise<string>;
-	arrayBuffer: () => Promise<ArrayBuffer>;
 	toString: () => '[object Blob]';
-
 }
 
 declare const FetchBlob: {


### PR DESCRIPTION
The removed methods are present on the `Blob` that we are `extends`-ing:

https://github.com/microsoft/TypeScript/blob/dbaeed5ad87cf846dddf0d278df3699e9f91cd21/lib/lib.dom.d.ts#L2537-L2544