### PR TITLE
Use upstream Blob directly in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
 /// <reference lib="dom"/>
 
+/* global Blob */
 export = Blob;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
 /// <reference lib="dom"/>
 
-/* global Blob */
 export = Blob;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,4 @@
 /// <reference lib="dom"/>
 
-/** A file-like object of immutable, raw data. Blobs represent data that isn't necessarily in a JavaScript-native format. The File interface is based on Blob, inheriting blob functionality and expanding it to support files on the user's system. */
-declare interface FetchBlob extends Blob {
-	[Symbol.toStringTag]: 'Blob';
-	stream: () => ReadableStream;
-	text: () => Promise<string>;
-	arrayBuffer: () => Promise<ArrayBuffer>;
-	toString: () => '[object Blob]';
-
-}
-
-declare const FetchBlob: {
-	prototype: FetchBlob;
-	new(blobParts?: BlobPart[], options?: BlobPropertyBag): FetchBlob;
-};
-
-export = FetchBlob;
+/* global Blob */
+export = Blob;


### PR DESCRIPTION
Alternative approach to #37 

I think that the reason that these were included in the first place was because they weren't present in upstream TypeScript at the time. This have been fixed now with: https://github.com/microsoft/TypeScript/pull/36164

The drawback of this is that we are removing `[Symbol.toStringTag]` and `toString`. But if we think that it's correct to have them on the `Blob` I think it would be better to submit patches upstream to add that instead, since the idea behind this package is to bring `Blob` cross platform.

Since we haven't yet published a version with typings this would not be a breaking change!

Closes: #37 