### PR TITLE
Operate on blob parts (byte sequence)

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ class Blob {
 
 		for (const part of parts) {
 			const size = ArrayBuffer.isView(part) ? part.byteLength : part.size;
-			if (relativeStart && size < relativeStart) {
+			if (relativeStart && size <= relativeStart) {
 				// Skip the beginning and change the relative
 				// start & end position as we skip the unwanted parts
 				relativeStart -= size;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const {Readable} = require('stream');
 
 /**
- * @type {WeakMap<Blob, { type: string, size: number, parts: Array }}
+ * @type {WeakMap<Blob, {type: string, size: number, parts: (Blob | Buffer)[] }>}
  */
 const wm = new WeakMap();
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 const {Readable} = require('stream');
 
+/**
+ * @type {WeakMap<Blob, { type: string, size: number, parts: Array }}
+ */
 const wm = new WeakMap();
 
 async function * read(parts) {
@@ -12,6 +15,11 @@ async function * read(parts) {
 	}
 }
 
+/**
+ * @template T
+ * @param {T} object
+ * @returns {T is Blob}
+ */
 const isBlob = object => {
 	return (
 		typeof object === 'object' &&
@@ -35,7 +43,7 @@ class Blob {
 
 		const parts = blobParts.map(element => {
 			let buffer;
-			if (element instanceof Buffer) {
+			if (Buffer.isBuffer(element)) {
 				buffer = element;
 			} else if (ArrayBuffer.isView(element)) {
 				buffer = Buffer.from(element.buffer, element.byteOffset, element.byteLength);
@@ -112,13 +120,6 @@ class Blob {
 	 */
 	stream() {
 		return Readable.from(read(wm.get(this).parts));
-	}
-
-	/**
-	 * @returns {string}
-	 */
-	toString() {
-		return '[object Blob]';
 	}
 
 	/**

--- a/index.js
+++ b/index.js
@@ -1,16 +1,39 @@
-// Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
-// (MIT licensed)
-
-const {Readable: ReadableStream} = require('stream');
+const {Readable} = require('stream');
 
 const wm = new WeakMap();
 
+async function * read(parts) {
+	for (const part of parts) {
+		if ('stream' in part) {
+			yield * part.stream();
+		} else {
+			yield part;
+		}
+	}
+}
+
+const isBlob = object => {
+	return (
+		typeof object === 'object' &&
+		typeof object.stream === 'function' &&
+		typeof object.constructor === 'function' &&
+		/^(Blob|File)$/.test(object[Symbol.toStringTag])
+	);
+};
+
 class Blob {
+	/**
+	 * The Blob() constructor returns a new Blob object. The content
+	 * of the blob consists of the concatenation of the values given
+	 * in the parameter array.
+	 *
+	 * @param {(ArrayBufferLike | ArrayBufferView | Blob | Buffer | string)[]} blobParts
+	 * @param {{ type?: string }} [options]
+	 */
 	constructor(blobParts = [], options = {type: ''}) {
-		const buffers = [];
 		let size = 0;
 
-		blobParts.forEach(element => {
+		const parts = blobParts.map(element => {
 			let buffer;
 			if (element instanceof Buffer) {
 				buffer = element;
@@ -18,89 +41,129 @@ class Blob {
 				buffer = Buffer.from(element.buffer, element.byteOffset, element.byteLength);
 			} else if (element instanceof ArrayBuffer) {
 				buffer = Buffer.from(element);
-			} else if (element instanceof Blob) {
-				buffer = wm.get(element).buffer;
+			} else if (isBlob(element)) {
+				buffer = element;
 			} else {
 				buffer = Buffer.from(typeof element === 'string' ? element : String(element));
 			}
 
-			size += buffer.length;
-			buffers.push(buffer);
+			size += buffer.length || buffer.size || 0;
+			return buffer;
 		});
-
-		const buffer = Buffer.concat(buffers, size);
 
 		const type = options.type === undefined ? '' : String(options.type).toLowerCase();
 
 		wm.set(this, {
 			type: /[^\u0020-\u007E]/.test(type) ? '' : type,
 			size,
-			buffer
+			parts
 		});
 	}
 
+	/**
+	 * The Blob interface's size property returns the
+	 * size of the Blob in bytes.
+	 */
 	get size() {
 		return wm.get(this).size;
 	}
 
+	/**
+	 * The type property of a Blob object returns the MIME type of the file.
+	 */
 	get type() {
 		return wm.get(this).type;
 	}
 
-	text() {
-		return Promise.resolve(wm.get(this).buffer.toString());
+	/**
+	 * The text() method in the Blob interface returns a Promise
+	 * that resolves with a string containing the contents of
+	 * the blob, interpreted as UTF-8.
+	 *
+	 * @return {Promise<string>}
+	 */
+	async text() {
+		return Buffer.from(await this.arrayBuffer()).toString();
 	}
 
-	arrayBuffer() {
-		const buf = wm.get(this).buffer;
-		const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
-		return Promise.resolve(ab);
+	/**
+	 * The arrayBuffer() method in the Blob interface returns a
+	 * Promise that resolves with the contents of the blob as
+	 * binary data contained in an ArrayBuffer.
+	 *
+	 * @return {Promise<ArrayBuffer>}
+	 */
+	async arrayBuffer() {
+		const data = new Uint8Array(this.size);
+		let offset = 0;
+		for await (const chunk of this.stream()) {
+			data.set(chunk, offset);
+			offset += chunk.length;
+		}
+
+		return data.buffer;
 	}
 
+	/**
+	 * The Blob interface's stream() method is difference from native
+	 * and uses node streams instead of whatwg streams.
+	 *
+	 * @returns {Readable} Node readable stream
+	 */
 	stream() {
-		const readable = new ReadableStream();
-		readable._read = () => { };
-		readable.push(wm.get(this).buffer);
-		readable.push(null);
-		return readable;
+		return Readable.from(read(wm.get(this).parts));
 	}
 
+	/**
+	 * @returns {string}
+	 */
 	toString() {
 		return '[object Blob]';
 	}
 
-	slice(...args) {
+	/**
+	 * The Blob interface's slice() method creates and returns a
+	 * new Blob object which contains data from a subset of the
+	 * blob on which it's called.
+	 *
+	 * @param {number} [start]
+	 * @param {number} [end]
+	 * @param {string} [contentType]
+	 */
+	slice(start = 0, end = this.size, type = '') {
 		const {size} = this;
 
-		const start = args[0];
-		const end = args[1];
-		let relativeStart;
-		let relativeEnd;
-
-		if (start === undefined) {
-			relativeStart = 0; //
-		} else if (start < 0) {
-			relativeStart = Math.max(size + start, 0); //
-		} else {
-			relativeStart = Math.min(start, size);
-		}
-
-		if (end === undefined) {
-			relativeEnd = size; //
-		} else if (end < 0) {
-			relativeEnd = Math.max(size + end, 0); //
-		} else {
-			relativeEnd = Math.min(end, size);
-		}
+		let relativeStart = start < 0 ? Math.max(size + start, 0) : Math.min(start, size);
+		let relativeEnd = end < 0 ? Math.max(size + end, 0) : Math.min(end, size);
 
 		const span = Math.max(relativeEnd - relativeStart, 0);
-		const slicedBuffer = wm.get(this).buffer.slice(
-			relativeStart,
-			relativeStart + span
-		);
-		const blob = new Blob([], {type: args[2]});
-		const _ = wm.get(blob);
-		_.buffer = slicedBuffer;
+		const parts = wm.get(this).parts.values();
+		const blobParts = [];
+		let added = 0;
+
+		for (const part of parts) {
+			const size = ArrayBuffer.isView(part) ? part.byteLength : part.size;
+			if (relativeStart && size < relativeStart) {
+				// Skip the beginning and change the relative
+				// start & end position as we skip the unwanted parts
+				relativeStart -= size;
+				relativeEnd -= size;
+			} else {
+				const chunk = part.slice(relativeStart, Math.min(size, relativeEnd));
+				blobParts.push(chunk);
+				added += size;
+				relativeStart = 0; // All next sequental parts should start at 0
+
+				// don't add the overflow to new blobParts
+				if (added >= span) {
+					break;
+				}
+			}
+		}
+
+		const blob = new Blob([], {type});
+		Object.assign(wm.get(blob), {size: span, parts: blobParts});
+
 		return blob;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node-fetch"
   ],
   "engines": {
-    "node": ">=6"
+    "node": "^10.17.0"
   },
   "author": "David Frank",
   "license": "MIT",

--- a/test.js
+++ b/test.js
@@ -113,6 +113,11 @@ test('Blob slice(0, -1)', async t => {
 	t.is(await blob.text(), 'abcdefg');
 });
 
+test('throw away unwanted parts', async t => {
+	const blob = new Blob(['a', 'b', 'c']).slice(1, 2);
+	t.is(await blob.text(), 'b');
+});
+
 test('Blob works with node-fetch Response.blob()', async t => {
 	const data = 'a=1';
 	const type = 'text/plain';


### PR DESCRIPTION
This PR makes fetch-blob extendable to work with any 3th party blobs by still using them as the source

---

I was successful at using this [http-blob WebIDL like](https://github.com/transcend-io/conflux/issues/31) reader and add it into fetch-blob using the following code

```js
new Blob([ new HttpFileLike(...) ])
```

No binary have been read, size still reflect correctly (even after using slice)
the http request isn't being made until i actually call `blob.arrayBuffer()`, text or stream

---

this will also make it possible to later add in File entries that is backed up by the file system later - you won't have to add anything into the memory and it will still be able to slice and read chunks

Doing something like this now won't end up resulting in 4 gib ram being used
```js
var file1 = File.from(path_to_2gib) // blob like backed up by fs
var file2 = File.from(path_to_2gib)

var concated = new Blob([file1, file2])
```
you will still be able to read both file as one single blob

closes #40 