### PR TITLE
Create blob backed up by filesystem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           node-version: ${{steps.get-version.outputs.node}}
 
       - run: npm install
+      - run: npm install domexception
 
       - run: npm run report -- --colors
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ fetch('https://httpbin.org/post', {
 ```
 
 ### Blob part backed up by filesystem
-you need to install optional domexception too
+To use, install [domexception](https://github.com/jsdom/domexception).
 
 ```sh
 npm install fetch-blob domexception

--- a/README.md
+++ b/README.md
@@ -27,6 +27,24 @@ fetch('https://httpbin.org/post', {
     .then(json => console.log(json));
 ```
 
+### Blob part backed up by filesystem
+you need to install optional domexception too
+
+```sh
+npm install fetch-blob domexception
+```
+
+```js
+const blobFrom = require('fetch-blob/from.js');
+const blob1 = blobFrom('./2-GiB-file.bin');
+const blob2 = blobFrom('./2-GiB-file.bin');
+
+// Not a 4 GiB memory snapshot, just holds 3 references
+// points to where data is located on the disk
+const blob = new Blob([blob1, blob2]);
+console.log(blob.size) // 4 GiB
+```
+
 See the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Blob) and [tests](https://github.com/node-fetch/fetch-blob/blob/master/test.js) for more details.
 
 [npm-image]: https://flat.badgen.net/npm/v/fetch-blob

--- a/from.js
+++ b/from.js
@@ -4,6 +4,7 @@ const DOMException = require('domexception');
 
 /**
  * @param {string} path filepath on the disk
+ * @returns {Blob}
  */
 function blobFrom(path) {
 	const {size, mtime} = statSync(path);

--- a/from.js
+++ b/from.js
@@ -1,0 +1,56 @@
+const {statSync, createReadStream} = require('fs');
+const Blob = require('.');
+const DOMException = require('domexception');
+
+/**
+ * @param {string} path filepath on the disk
+ */
+function blobFrom(path) {
+	const {size, mtime} = statSync(path);
+	const blob = new BlobDataItem({path, size, mtime});
+
+	return new Blob([blob]);
+}
+
+/**
+ * This is a blob backed up by a file on the disk
+ * with minium requirement
+ *
+ * @private
+ */
+class BlobDataItem {
+	constructor(options) {
+		this.size = options.size;
+		this.path = options.path;
+		this.start = options.start;
+		this.mtime = options.mtime;
+	}
+
+	// Slicing arguments is validated and formated
+	// by Blob.prototype.slice
+	slice(start, end) {
+		return new BlobDataItem({
+			path: this.path,
+			start,
+			mtime: this.mtime,
+			size: end - start
+		});
+	}
+
+	stream() {
+		if (statSync(this.path).mtime > this.mtime) {
+			throw new DOMException('The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.', 'NotReadableError');
+		}
+
+		return createReadStream(this.path, {
+			start: this.start,
+			end: this.start + this.size - 1
+		});
+	}
+
+	get [Symbol.toStringTag]() {
+		return 'Blob';
+	}
+}
+
+module.exports = blobFrom;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
             }
         ]
     },
-    "dependencies": {}
+    "dependencies": {},
     "optionalDependencies": {
         "domexception": "^2.0.1"
     }

--- a/package.json
+++ b/package.json
@@ -49,4 +49,7 @@
         ]
     },
     "dependencies": {}
+    "optionalDependencies": {
+        "domexception": "^2.0.1"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
             }
         ]
     },
-    "dependencies": {},
-    "optionalDependencies": {
+    "peerDependencies": {
         "domexception": "^2.0.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "A Blob implementation in Node.js, originally from node-fetch.",
     "main": "index.js",
     "files": [
+        "from.js",
         "index.js",
         "index.d.ts"
     ],

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const test = require('ava');
 const Blob = require('.');
 const blobFrom = require('./from');
@@ -148,4 +149,14 @@ test('blob part backed up by filesystem', async t => {
 	const blob = blobFrom('./LICENSE');
 	t.is(await blob.slice(0, 3).text(), 'MIT');
 	t.is(await blob.slice(4, 11).text(), 'License');
+});
+
+test('Reading after modified should fail', async t => {
+	const blob = blobFrom('./LICENSE');
+	await new Promise(rs => setTimeout(rs, 100))
+	const now = new Date();
+	// Change modified time
+	fs.utimesSync('./LICENSE', now, now);
+	const error = await blob.text().catch(e => e);
+	t.is(error.name, 'NotReadableError');
 });

--- a/test.js
+++ b/test.js
@@ -153,10 +153,10 @@ test('blob part backed up by filesystem', async t => {
 
 test('Reading after modified should fail', async t => {
 	const blob = blobFrom('./LICENSE');
-	await new Promise(rs => setTimeout(rs, 100))
+	await new Promise(resolve => setTimeout(resolve, 100));
 	const now = new Date();
 	// Change modified time
 	fs.utimesSync('./LICENSE', now, now);
-	const error = await blob.text().catch(e => e);
+	const error = await blob.text().catch(error => error);
 	t.is(error.name, 'NotReadableError');
 });

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 const test = require('ava');
 const Blob = require('.');
+const blobFrom = require('./from');
 const getStream = require('get-stream');
 const {Response} = require('node-fetch');
 const {TextDecoder} = require('util');
@@ -141,4 +142,10 @@ test('Blob works with node-fetch Response.text()', async t => {
 	const response = new Response(blob);
 	const text = await response.text();
 	t.is(text, data);
+});
+
+test('blob part backed up by filesystem', async t => {
+	const blob = blobFrom('./LICENSE');
+	t.is(await blob.slice(0, 3).text(), 'MIT');
+	t.is(await blob.slice(4, 11).text(), 'License');
 });


### PR DESCRIPTION
haven't been any discussion about how to go about solving this so i have made a first attempt/design at creating a blob backed up by filesystem.

Think this could be useful for ppl who need to to work with FormData for example 
```js
const blobFrom = require('fetch-blob/from.js')
const fd = new FormData()
const blob = blobFrom('./wallpaper.png')
fd.append('portrait', blob, 'wallpaper.png')
```

This don't add to the bundle size unless you implicit import/require "fetch-blob/from.js"

---

i first thought about doing something like `blob = Blob.from(path)` but that would make it different from the spec and adds to the bundle cost