### PR TITLE
Fix Node compatibility error for Node @ 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "node-fetch"
     ],
     "engines": {
-        "node": "^10.17.0 || >=12.3.0"
+        "node": ">=10.17.0"
     },
     "author": "David Frank",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "node-fetch"
     ],
     "engines": {
-        "node": ">=10.17.0"
+        "node": ">=12.3.0 || ^10.17.0"
     },
     "author": "David Frank",
     "license": "MIT",


### PR DESCRIPTION
An incorrect setting for the `engines` filed in the project's `package.json` is causing install errors for major versions of node above v10, such as the following:

```bash
error fetch-blob@1.0.7: The engine "node" is incompatible with this module. Expected version "^10.17.0"
. Got "14.10.0"
```
After running into this error I tried updating both node and yarn to the latest versions (`14.11.0` and `1.22.5` respectively) and continued to get an incompatible module error.

It would appear that the or condition isn't being checked, so while `^14.10.0` should satisfy `>=12.3.0`, semver isn't checking against that condition and fast failing on `^10.17.0` instead, limiting the major version range. Swapping the order of this semver rule may solve for this error.

Additional CI tests may be required, but I'm unsure how to properly configure those.