### PR TITLE
Add generated typings for from.js file.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
           node-version: ${{steps.get-version.outputs.node}}
 
       - run: npm install
-      - run: npm install domexception
 
       - run: npm run report -- --colors
 

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,4 @@ typings/
 # dotenv environment variables file
 .env
 
-index.d.ts
+@types

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,5 @@ typings/
 # dotenv environment variables file
 .env
 
-@types
+index.d.ts
+from.d.ts

--- a/from.js
+++ b/from.js
@@ -1,5 +1,5 @@
 const {statSync, createReadStream} = require('fs');
-const Blob = require('./index.js');
+const Blob = require('.');
 const DOMException = require('domexception');
 
 /**
@@ -27,7 +27,7 @@ class BlobDataItem {
 		this.mtime = options.mtime;
 	}
 
-	// Slicing arguments is first validated and formated 
+	// Slicing arguments is first validated and formated
 	// to not be out of range by Blob.prototype.slice
 	slice(start, end) {
 		return new BlobDataItem({

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "test": "xo && ava",
         "report": "c8 --reporter json --reporter text ava",
         "coverage": "c8 --reporter json --reporter text ava && codecov -f coverage/coverage-final.json",
-        "prepublishOnly": "tsc --declaration --emitDeclarationOnly --allowJs index.js"
+        "prepublishOnly": "tsc --declaration --emitDeclarationOnly --allowJs --outDir @types index.js from.js"
     },
     "repository": "https://github.com/node-fetch/fetch-blob.git",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -6,15 +6,15 @@
     "files": [
         "from.js",
         "index.js",
-        "@types/index.d.ts",
-        "@types/from.d.ts"
+        "index.d.ts",
+        "from.d.ts"
     ],
     "scripts": {
         "lint": "xo",
         "test": "xo && ava",
         "report": "c8 --reporter json --reporter text ava",
         "coverage": "c8 --reporter json --reporter text ava && codecov -f coverage/coverage-final.json",
-        "prepublishOnly": "tsc --declaration --emitDeclarationOnly --allowJs --outDir @types index.js from.js"
+        "prepublishOnly": "tsc --declaration --emitDeclarationOnly --allowJs index.js from.js"
     },
     "repository": "https://github.com/node-fetch/fetch-blob.git",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "files": [
         "from.js",
         "index.js",
-        "index.d.ts"
+        "@types/index.d.ts",
+        "@types/from.d.ts"
     ],
     "scripts": {
         "lint": "xo",
@@ -33,6 +34,7 @@
         "ava": "^3.8.2",
         "c8": "^7.2.0",
         "codecov": "^3.7.0",
+        "domexception": "^2.0.1",
         "get-stream": "^5.1.0",
         "node-fetch": "^2.6.0",
         "typescript": "^3.9.5",


### PR DESCRIPTION
This pull request brings missing types for Blob backed by `fs`. It addresses the issue when TS asking to install missing types for `fetch-blob/from.js` or write corresponding declaration file:

<details>
<summary>Details</summary>

![2021-04-14 02 42 44](https://user-images.githubusercontent.com/7884558/114634507-57c8be80-9ccb-11eb-8fd7-570596f2943f.jpg)

</details>

----
I also added `domexception` into devDependencies because tests are failing without it. I think it's fine to have it here rather then install it manually every time you clone the repo and need to run through tests. It also won't be included once you run `npm install fetch-blob` to install the package. Please, let me know if it has to be reverted for a reason, because I don't really understand why you did that.