### PR TITLE
Add nullish values checking in Symbol.hasInstance

### DIFF
--- a/from.js
+++ b/from.js
@@ -1,5 +1,5 @@
 const {statSync, createReadStream} = require('fs');
-const Blob = require('.');
+const Blob = require('./index');
 const DOMException = require('domexception');
 
 /**

--- a/from.js
+++ b/from.js
@@ -1,5 +1,5 @@
 const {statSync, createReadStream} = require('fs');
-const Blob = require('./index');
+const Blob = require('./index.js');
 const DOMException = require('domexception');
 
 /**

--- a/from.js
+++ b/from.js
@@ -1,5 +1,5 @@
 const {statSync, createReadStream} = require('fs');
-const Blob = require('./index.js');
+const Blob = require('.');
 const DOMException = require('domexception');
 
 /**
@@ -27,7 +27,7 @@ class BlobDataItem {
 		this.mtime = options.mtime;
 	}
 
-	// Slicing arguments is first validated and formated 
+	// Slicing arguments is first validated and formated
 	// to not be out of range by Blob.prototype.slice
 	slice(start, end) {
 		return new BlobDataItem({

--- a/from.js
+++ b/from.js
@@ -1,7 +1,7 @@
 const {statSync, createReadStream} = require('fs');
 const DOMException = require('domexception');
 
-// slint-disable-next-line unicorn/import-index
+// eslint-disable-next-line unicorn/import-index
 const Blob = require('./index.js');
 
 /**

--- a/from.js
+++ b/from.js
@@ -1,6 +1,8 @@
 const {statSync, createReadStream} = require('fs');
-const Blob = require('./index.js');
 const DOMException = require('domexception');
+
+// slint-disable-next-line unicorn/import-index
+const Blob = require('./index.js');
 
 /**
  * @param {string} path filepath on the disk

--- a/index.js
+++ b/index.js
@@ -160,6 +160,7 @@ class Blob {
 
 	static [Symbol.hasInstance](object) {
 		return (
+			object &&
 			typeof object === 'object' &&
 			typeof object.stream === 'function' &&
 			object.stream.length === 0 &&

--- a/test.js
+++ b/test.js
@@ -173,6 +173,6 @@ test('Blob-ish class is an instance of Blob', t => {
 	t.true(new File() instanceof Blob);
 });
 
-test('Nullish value returns false for instanceof check with Blob', t => {
+test('Instanceof check returns false for nullish values', t => {
 	t.false(null instanceof Blob);
 });

--- a/test.js
+++ b/test.js
@@ -160,3 +160,19 @@ test('Reading after modified should fail', async t => {
 	const error = await blob.text().catch(error => error);
 	t.is(error.name, 'NotReadableError');
 });
+
+test('Blob-ish class is an instance of Blob', t => {
+	class File {
+		stream() { }
+
+		get [Symbol.toStringTag]() {
+			return 'File';
+		}
+	}
+
+	t.true(new File() instanceof Blob);
+});
+
+test('Nullish value returns false for instanceof check with Blob', t => {
+	t.false(null instanceof Blob);
+});


### PR DESCRIPTION
Browser version of Blob seem to return `false` in case when you check nullish values for being an instance of `Blob`. Tried in Firefox, Chrome and Safari.
This should resolve the issue https://github.com/node-fetch/fetch-blob/issues/58

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/7884558/115315122-555cdd80-a17f-11eb-8f95-4bbb693b9ab0.png)

</details>