### PR TITLE
Fix for the 'start' range of BlobDataItem when reading its stream

### DIFF
--- a/from.js
+++ b/from.js
@@ -34,7 +34,7 @@ class BlobDataItem {
 			path: this.path,
 			start,
 			mtime: this.mtime,
-			size: end - start
+			size: start ? end - start : end
 		});
 	}
 
@@ -45,7 +45,7 @@ class BlobDataItem {
 
 		return createReadStream(this.path, {
 			start: this.start,
-			end: this.start + this.size - 1
+			end: (this.start ? this.start + this.size : this.size) - 1
 		});
 	}
 

--- a/from.js
+++ b/from.js
@@ -23,7 +23,7 @@ class BlobDataItem {
 	constructor(options) {
 		this.size = options.size;
 		this.path = options.path;
-		this.start = options.start;
+		this.start = options.start || 0;
 		this.mtime = options.mtime;
 	}
 
@@ -34,7 +34,7 @@ class BlobDataItem {
 			path: this.path,
 			start,
 			mtime: this.mtime,
-			size: start ? end - start : end
+			size: end - start
 		});
 	}
 
@@ -45,7 +45,7 @@ class BlobDataItem {
 
 		return createReadStream(this.path, {
 			start: this.start,
-			end: (this.start ? this.start + this.size : this.size) - 1
+			end: this.start + this.size - 1
 		});
 	}
 

--- a/test.js
+++ b/test.js
@@ -163,6 +163,15 @@ test('Reading after modified should fail', async t => {
 	t.is(error.name, 'NotReadableError');
 });
 
+test('Reading from the stream created by blobFrom', async t => {
+	const blob = blobFrom('./LICENSE');
+	const expected = await fs.promises.readFile('./LICENSE', 'utf-8');
+
+	const actual = await getStream(blob.stream());
+
+	t.is(actual, expected);
+});
+
 test('Blob-ish class is an instance of Blob', t => {
 	class File {
 		stream() {}


### PR DESCRIPTION
I was trying to upgrade fetch-blob to the latest version and got the following error when I run my tests:

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/7884558/115970588-041c6780-a54c-11eb-998d-807256ea9e1e.png)


</details>

You can also reproduce this from node REPL:

1. Clone fetch-blob to your local machine
2. Install dependencies as usual
3. Open .editor REPL:
4. Put this code into console, then hit `Ctrl+D` to run it:

```js
const {createWriteStream} = require("fs")

const blobFromPath = require("./from")

void blobFromPath("./LICENSE").stream().pipe(createWriteStream("/dev/null"))
```

Tried this on Node v15.13.0 and v16.0.0

Seems like the error appears because you didn't check if the `start` option present.
Here: https://github.com/node-fetch/fetch-blob/blob/cc929f371476f69fc31d6b0d02b2cf13b4be76e2/from.js#L48

So when the `start` option is not set, the result of this operation would be `NaN`.

I think it also happens here: https://github.com/node-fetch/fetch-blob/blob/cc929f371476f69fc31d6b0d02b2cf13b4be76e2/from.js#L37

This PR should solve the problem.

I was also thinking to just set the start to 0 by default, but I'm not sure if I understand how Node.js will handle ReadStream in this case.
