### PR TITLE
Return empty a empty stream for zero sized blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## next
+- Fixed a bug where in BlobDataItem when the file was empty (#86)
+
+## v2.1.2
+- Fixed a bug where `start` in BlobDataItem was undefined (#85)
+
 ## v2.1.1
 - Add nullish values checking in Symbol.hasInstance (#82)
 - Add generated typings for from.js file (#80)

--- a/from.js
+++ b/from.js
@@ -43,6 +43,10 @@ class BlobDataItem {
 			throw new DOMException('The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.', 'NotReadableError');
 		}
 
+		if (!this.size) {
+			return new Blob().stream();
+		}
+
 		return createReadStream(this.path, {
 			start: this.start,
 			end: this.start + this.size - 1

--- a/test.js
+++ b/test.js
@@ -172,6 +172,12 @@ test('Reading from the stream created by blobFrom', async t => {
 	t.is(actual, expected);
 });
 
+test('Reading empty blobs', async t => {
+	const blob = blobFrom('./LICENSE').slice(0, 0);
+	const actual = await blob.text();
+	t.is(actual, '');
+});
+
 test('Blob-ish class is an instance of Blob', t => {
 	class File {
 		stream() {}


### PR DESCRIPTION
`createReadStream(x, {start:0, end:0})` throws a out of bound error - so just return a empty stream instead