### PR TITLE
Async version for blobFrom

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,33 @@ npm install fetch-blob domexception
 ```
 
 ```js
-const blobFrom = require('fetch-blob/from.js');
-const blob1 = blobFrom('./2-GiB-file.bin');
-const blob2 = blobFrom('./2-GiB-file.bin');
+const blobFromSync = require('fetch-blob/from.js');
+const blob1 = blobFromSync('./2-GiB-file.bin');
+const blob2 = blobFromSync('./2-GiB-file.bin');
 
 // Not a 4 GiB memory snapshot, just holds 3 references
 // points to where data is located on the disk
 const blob = new Blob([blob1, blob2]);
 console.log(blob.size) // 4 GiB
+```
+
+blobFrom has both asynchronous and synchronous versions:
+
+```js
+const {blobFrom, blobFromSync} = require("fetch-blob/from.js");
+
+const blob1 = blobFromSync('./2-GiB-file.bin');
+const blob2 = blobFromSync('./2-GiB-file.bin');
+
+const blob = new Blob([blob1, blob2]);
+
+// or if you want and async version
+(async function() {
+    const blob1 = await blobFrom('./2-GiB-file.bin');
+    const blob2 = await blobFrom('./2-GiB-file.bin');
+
+    const blob = new Blob([blob1, blob2]);
+}())
 ```
 
 See the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Blob) and [tests](https://github.com/node-fetch/fetch-blob/blob/master/test.js) for more details.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const blob2 = blobFromSync('./2-GiB-file.bin');
 
 const blob = new Blob([blob1, blob2]);
 
-// or if you want and async version
+// or if you want an async version
 (async function() {
     const blob1 = await blobFrom('./2-GiB-file.bin');
     const blob2 = await blobFrom('./2-GiB-file.bin');

--- a/from.js
+++ b/from.js
@@ -53,16 +53,16 @@ class BlobDataItem {
 		});
 	}
 
-	async* stream() {
+	async * stream() {
 		const {mtime} = await fs.stat(this.path);
 
 		if (mtime > this.mtime) {
 			throw new DOMException('The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.', 'NotReadableError');
 		}
 
-		yield* this.size
-			? createReadStream(this.path, {start: this.start, end: this.start + this.size - 1})
-			: new Blob().stream();
+		yield* this.size ?
+			createReadStream(this.path, {start: this.start, end: this.start + this.size - 1}) :
+			new Blob().stream();
 	}
 
 	get [Symbol.toStringTag]() {

--- a/from.js
+++ b/from.js
@@ -60,7 +60,7 @@ class BlobDataItem {
 			throw new DOMException('The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.', 'NotReadableError');
 		}
 
-		yield* this.size ?
+		yield * this.size ?
 			createReadStream(this.path, {start: this.start, end: this.start + this.size - 1}) :
 			new Blob().stream();
 	}

--- a/from.js
+++ b/from.js
@@ -72,5 +72,5 @@ class BlobDataItem {
 }
 
 module.exports = blobFromPathSync;
-module.exports.blobFrom = blobFromPath;
+module.exports.blobFromPath = blobFromPath;
 module.exports.blobFromPathSync = blobFromPathSync;

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const getStream = require('get-stream');
 const {Response} = require('node-fetch');
 const {TextDecoder} = require('util');
 const Blob = require('./index.js');
-const blobFrom = require('./from.js');
+const {blobFromSync, blobFrom} = require('./from.js');
 
 test('new Blob()', t => {
 	const blob = new Blob(); // eslint-disable-line no-unused-vars
@@ -146,13 +146,13 @@ test('Blob works with node-fetch Response.text()', async t => {
 });
 
 test('blob part backed up by filesystem', async t => {
-	const blob = blobFrom('./LICENSE');
+	const blob = blobFromSync('./LICENSE');
 	t.is(await blob.slice(0, 3).text(), 'MIT');
 	t.is(await blob.slice(4, 11).text(), 'License');
 });
 
 test('Reading after modified should fail', async t => {
-	const blob = blobFrom('./LICENSE');
+	const blob = blobFromSync('./LICENSE');
 	await new Promise(resolve => {
 		setTimeout(resolve, 100);
 	});
@@ -162,6 +162,15 @@ test('Reading after modified should fail', async t => {
 	const error = await blob.text().catch(error => error);
 	t.is(error.name, 'NotReadableError');
 });
+
+test('Reading file using async version of blobFrom', async t => {
+	const blob = await blobFrom('./LICENSE');
+	const expected = await fs.promises.readFile('./LICENSE', 'utf-8');
+
+	const actual = await getStream(blob.stream())
+
+	t.is(actual, expected)
+})
 
 test('Blob-ish class is an instance of Blob', t => {
 	class File {


### PR DESCRIPTION
This PR backports async version of the `blobFrom` function. I'm sending this because according to Node.js docs it seem to be impossible to load ES modules synchronously in CJS context: [see this interoperability section](https://nodejs.org/dist/latest/docs/api/esm.html#esm_require).

This PR is also does the following:
1. Renames an old `blobFrom` function to `blobFromSync`;
2. Brings named exports for both `blobFrom` and `blobFromSync`;
3. Keeps `blobFromSync` on as `module.exports` value because of compatibility reasons.