### PR TITLE
feat: bundle module and use package exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,5 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage/coverage-final.json
+
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ bower_components
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 
+# Compiled esbuild files
+dist/
+
 # Dependency directories
 node_modules/
 jspm_packages/

--- a/package.json
+++ b/package.json
@@ -2,23 +2,38 @@
     "name": "fetch-blob",
     "version": "3.1.2",
     "description": "Blob & File implementation in Node.js, originally from node-fetch.",
-    "main": "index.js",
+    "main": "dist/esm/index.mjs",
     "type": "module",
     "files": [
-        "from.js",
-        "file.js",
+        "dist",
         "file.d.ts",
-        "index.js",
         "index.d.ts",
-        "from.d.ts",
-        "streams.cjs"
+        "from.d.ts"
     ],
+    "exports": {
+        ".": {
+            "import": "./dist/esm/index.mjs",
+            "require": "./dist/cjs/index.cjs"
+        },
+        "./file": {
+            "import": "./dist/esm/file.mjs",
+            "require": "./dist/cjs/file.cjs"
+        },
+        "./from": {
+            "import": "./dist/esm/from.mjs",
+            "require": "./dist/cjs/from.cjs"
+        }
+    },
     "scripts": {
+        "build": "npm run build:esm && npm run build:cjs && npm run build:types",
+        "build:esm": "esbuild index.js --bundle --platform=node --format=esm --outfile=dist/esm/index.mjs && esbuild file.js from.js --platform=node --format=esm --outdir=dist/esm --out-extension:.js=.mjs",
+        "build:cjs": "esbuild index.js --bundle --platform=node --format=cjs --outfile=dist/cjs/index.cjs && esbuild file.js from.js --platform=node --format=cjs --outdir=dist/cjs --out-extension:.js=.cjs",
+        "build:types": "tsc --declaration --emitDeclarationOnly --allowJs index.js from.js",
         "lint": "xo test.js",
         "test": "npm run lint && ava",
         "report": "c8 --reporter json --reporter text ava",
         "coverage": "c8 --reporter json --reporter text ava && codecov -f coverage/coverage-final.json",
-        "prepublishOnly": "tsc --declaration --emitDeclarationOnly --allowJs index.js from.js"
+        "prepublishOnly": "npm run build"
     },
     "repository": "https://github.com/node-fetch/fetch-blob.git",
     "keywords": [
@@ -63,8 +78,10 @@
         "ava": "^3.15.0",
         "c8": "^7.7.2",
         "codecov": "^3.8.2",
+        "esbuild": "^0.12.16",
         "node-fetch": "^3.0.0-beta.9",
         "typescript": "^4.3.2",
+        "web-streams-polyfill": "^3.0.3",
         "xo": "^0.40.1"
     },
     "funding": [
@@ -76,8 +93,5 @@
             "type": "paypal",
             "url": "https://paypal.me/jimmywarting"
         }
-    ],
-    "dependencies": {
-        "web-streams-polyfill": "^3.0.3"
-    }
+    ]
 }


### PR DESCRIPTION
As explained in node-fetch/node-fetch#1226, the fact that `fetch-blob` v3 is now pure ESM causes multiple problems with existing codebases.

In JavaScript codebases, we need to use the async `import()` which can create a lot of changes.
In TypeScript codebases (with cjs module mode), it is impossible to use `fetch-blob` anymore.

I think that ESM is the future but it is not as stable as we think and it is not ready to be used everywhere.
The best way to ensure that all existing codebases can migrate to v3 is to provide both `cjs` and `esm` versions of this module.

For this, I introduced `esbuild` which can transpile ESM to CJS and also can bundle the package.

You can say: "node does not need packages to be bundled", which is true.
However, bundling is a good practice to reduce the module loading time, disk operations, memory footprint, etc.

It can also be used to bundle internal dependencies and so reduce the npm dependency tree (reduce install time, disk operations, memory footprint, npm hell, etc.).

Bundling `web-streams-polyfill` makes this module install size reduce from 6.5MB to 341kB.

This PR is linked to node-fetch/node-fetch#1227. It allows to avoid bundling `fetch-blob` in `node-fetch` when providing the commonjs version of the package.

**What's included in this PR**

- use esbuild to bundle module in esm and cjs format
- bundle dependencies to reduce module size
- use package exports to automatically select the apropriate version
- add build step to prepublishOnly
- add build step to ci