### PR TITLE
fix(blob-stream): Bump major web stream polyfill v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
         }
     ],
     "dependencies": {
-        "web-streams-polyfill": "^3.0.3"
+        "web-streams-polyfill": "^4.0.0-beta.1"
     }
 }

--- a/streams.cjs
+++ b/streams.cjs
@@ -7,7 +7,7 @@ if (!globalThis.ReadableStream) {
     Object.assign(globalThis, require('stream/web'))
   } catch (error) {
 		// TODO: Remove when only supporting node >= 16.5.0
-    Object.assign(globalThis, require('web-streams-polyfill/dist/ponyfill.es2018.js'))
+    require('web-streams-polyfill/polyfill')
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -388,9 +388,7 @@ test('returns a readable stream', t => {
 	t.true(typeof stream.getReader === 'function');
 });
 
-test('checking instanceof blob#stream', async t => {
-	// eslint-disable-next-line node/no-unsupported-features/es-syntax
-	const {ReadableStream} = await import('stream/web').catch(_ => import('web-streams-polyfill/dist/ponyfill.es2018.js'));
+test('checking instanceof blob#stream', t => {
 	const stream = new File([], '').stream();
-	t.true(stream instanceof ReadableStream);
+	t.true(stream instanceof globalThis.ReadableStream);
 });


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## The purpose of this PR is:
To reduce file size.

## This is what had to change:
- Needed to bump web-stream-polyfill to next major version

## This is what I like reviewers to know:

just b/c stream polyfill made a breaking change dose not mean we have to do it. The Blob API stays the same... 
a patch release might be sufficient
I have just changed the way we import the polyfill

-------------------------------------------------------------------------------------------------

<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
- [x] I prefixed the PR-title with `docs: `, `fix(scope): `, `feat(scope): ` or `breaking(scope): `
- [ ] I updated ./CHANGELOG.md with a link to this PR or Issue
- [x] I updated one unit test
- [ ] Wait for v4 stable to be released. This PR is as of now just a draft/wip. (just want to see how CI handles the test)<br>(Promised I would give a review and test the beta for Mattias)
  - [ ] update this PR with newest (stable) v4 of stream polyfill when released (blocks this PR)
-------------------------------------------------------------------------------------------------

<!-- Add a `- fix #_NUMBER_` line for every Issue this PR solves. Do not comma separate them -->
- fix https://github.com/node-fetch/node-fetch/issues/1217
