### PR TITLE
Add fatal flag to TextDecoder to fix inconsistency

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ const _Blob = class Blob {
 	async text() {
 		// More optimized than using this.arrayBuffer()
 		// that requires twice as much ram
-		const decoder = new TextDecoder();
+		const decoder = new TextDecoder('utf-8', { fatal: false });
 		let str = '';
 		for await (let part of toIterator(this.#parts, false)) {
 			str += decoder.decode(part, { stream: true });


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## The purpose of this PR is:
Fix inconsistency between `fetch-blob` and the browser File behavior.
https://github.com/node-fetch/fetch-blob/issues/118

## This is what had to change:
Make invalid utf-8 decoding non fatal


