### PR TITLE
fix(blob, file, tests): Minor improvements for Blob and File implementations

### DIFF
--- a/file.js
+++ b/file.js
@@ -17,8 +17,12 @@ const _File = class File extends Blob {
 
     if (options === null) options = {};
 
-    const modified = Number(options.lastModified);
-    this.#lastModified = Number.isNaN(modified) ? Date.now() : modified
+    // Simulate WebIDL type casting for NaN value in lastModified option.
+    const lastModified = options.lastModified === undefined ? Date.now() : Number(options.lastModified);
+    if (!Number.isNaN(lastModified)) {
+      this.#lastModified = lastModified;
+    }
+
     this.#name = String(fileName);
   }
 

--- a/index.js
+++ b/index.js
@@ -58,8 +58,6 @@ const _Blob = class Blob {
 	 * @param {{ type?: string }} [options]
 	 */
 	constructor(blobParts = [], options = {}) {
-		const parts = [];
-		let size = 0;
 		if (typeof blobParts !== 'object') {
 			throw new TypeError(`Failed to construct 'Blob': parameter 1 is not an iterable object.`);
 		}
@@ -82,15 +80,13 @@ const _Blob = class Blob {
 				part = new TextEncoder().encode(element);
 			}
 
-			size += ArrayBuffer.isView(part) ? part.byteLength : part.size;
-			parts.push(part);
+			this.#size += ArrayBuffer.isView(part) ? part.byteLength : part.size;
+			this.#parts.push(part);
 		}
 
 		const type = options.type === undefined ? '' : String(options.type);
 
 		this.#type = /^[\x20-\x7E]*$/.test(type) ? type : '';
-		this.#size = size;
-		this.#parts = parts;
 	}
 
 	/**

--- a/index.js
+++ b/index.js
@@ -202,6 +202,10 @@ const _Blob = class Blob {
 			async pull(ctrl) {
 				const chunk = await it.next();
 				chunk.done ? ctrl.close() : ctrl.enqueue(chunk.value);
+			},
+
+			async cancel() {
+				await it.return()
 			}
 		})
 	}

--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ const _Blob = class Blob {
 
 		if (options === null) options = {};
 
+		const encoder = new TextEncoder()
 		for (const element of blobParts) {
 			let part;
 			if (ArrayBuffer.isView(element)) {
@@ -119,7 +120,7 @@ const _Blob = class Blob {
 			} else if (element instanceof Blob) {
 				part = element;
 			} else {
-				part = new TextEncoder().encode(element);
+				part = encoder.encode(element);
 			}
 
 			this.#size += ArrayBuffer.isView(part) ? part.byteLength : part.size;

--- a/index.js
+++ b/index.js
@@ -100,12 +100,16 @@ const _Blob = class Blob {
 	 * @param {{ type?: string }} [options]
 	 */
 	constructor(blobParts = [], options = {}) {
-		if (typeof blobParts !== 'object') {
-			throw new TypeError(`Failed to construct 'Blob': parameter 1 is not an iterable object.`);
-		}
+		if (typeof blobParts !== "object" || blobParts === null) {
+      throw new TypeError('Failed to construct \'Blob\': The provided value cannot be converted to a sequence.');
+    }
+
+		if (typeof blobParts[Symbol.iterator] !== "function") {
+      throw new TypeError('Failed to construct \'Blob\': The object must have a callable @@iterator property.');
+    }
 
 		if (typeof options !== 'object' && typeof options !== 'function') {
-			throw new TypeError(`Failed to construct 'Blob': parameter 2 cannot convert to dictionary.`);
+			throw new TypeError('Failed to construct \'Blob\': parameter 2 cannot convert to dictionary.');
 		}
 
 		if (options === null) options = {};

--- a/test.js
+++ b/test.js
@@ -133,6 +133,20 @@ test('Blob stream()', async t => {
 	}
 });
 
+test('Blob stream() can be cancelled', async t => {
+	const stream = new Blob(['Some content']).stream();
+
+	// Cancel the stream before start reading, or this will throw an error
+	await stream.cancel();
+
+	const iterator = stream[Symbol.asyncIterator]();
+
+	const {done, value: chunk} = await iterator.next();
+
+	t.true(done);
+	t.is(chunk, undefined);
+});
+
 test('Blob toString()', t => {
 	const data = 'a=1';
 	const type = 'text/plain';
@@ -365,12 +379,17 @@ test('new File(,,{lastModified: new Date()})', t => {
 	t.true(mod <= 0 && mod >= -20); // Close to tolerance: 0.020ms
 });
 
+test('new File(,,{lastModified: undefined})', t => {
+	const mod = new File([], '', {lastModified: undefined}).lastModified - Date.now();
+	t.true(mod <= 0 && mod >= -20); // Close to tolerance: 0.020ms
+});
+
 test('new File(,,{lastModified: null})', t => {
 	const mod = new File([], '', {lastModified: null}).lastModified;
 	t.is(mod, 0);
 });
 
-test("Interpretes NaN value in lastModified option as 0", t => {
+test('Interpretes NaN value in lastModified option as 0', t => {
 	t.plan(3);
 
 	const values = ['Not a Number', [], {}];

--- a/test.js
+++ b/test.js
@@ -365,6 +365,25 @@ test('new File(,,{lastModified: new Date()})', t => {
 	t.true(mod <= 0 && mod >= -20); // Close to tolerance: 0.020ms
 });
 
+test('new File(,,{lastModified: null})', t => {
+	const mod = new File([], '', {lastModified: null}).lastModified;
+	t.is(mod, 0);
+});
+
+test("Interpretes NaN value in lastModified option as 0", t => {
+	t.plan(3);
+
+	const values = ['Not a Number', [], {}];
+
+	// I can't really see anything about this in the spec,
+	// but this is how browsers handle type casting for this option...
+	for (const lastModified of values) {
+		const file = new File(['Some content'], 'file.txt', {lastModified});
+
+		t.is(file.lastModified, 0);
+	}
+});
+
 test('new File(,,{}) sets current time', t => {
 	const mod = new File([], '').lastModified - Date.now();
 	t.true(mod <= 0 && mod >= -20); // Close to tolerance: 0.020ms

--- a/test.js
+++ b/test.js
@@ -58,7 +58,17 @@ test('Blob ctor reads blob parts from object with @@iterator', async t => {
 });
 
 test('Blob ctor throws a string', t => {
-	t.throws(() => new Blob('abc'));
+	t.throws(() => new Blob('abc'), {
+		instanceOf: TypeError,
+		message: 'Failed to construct \'Blob\': The provided value cannot be converted to a sequence.'
+	});
+});
+
+test('Blob ctor throws an error for an object that does not have @@iterable method', t => {
+	t.throws(() => new Blob({}), {
+		instanceOf: TypeError,
+		message: 'Failed to construct \'Blob\': The object must have a callable @@iterator property.'
+	});
 });
 
 test('Blob ctor threats Uint8Array as a sequence', async t => {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## The purpose of this PR is:

This PR includes minor improvements and fixes for File and Blob internals

## This is what had to change:

- `Blob.stream().cancel()` triggers `iterator.return()` on underlying source;
- Improve type casting for `FilePropertyBag.lastModified` to match browsers behaviour (This behaviour tested in Chrome, Firefox and Safari), now NaN values will be interpreted as `0` rather than `Date.now()`;
- Improve errors reported by Blob constructor;
- Move `Blob.slice()` implementation outside the Blob class and implement it as generator function. Since blob treats iterable objects as a sequence and behaviour looks the same;
- Apply private values as we iterate over blob parts.

## This is what like reviewers to know:

This PR is more of a housekeeping with minor changes only. This also changes one thing in terms of File behaviour, just to match File implementations in browsers.

-------------------------------------------------------------------------------------------------

<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
- [x] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
- [ ] I updated ./CHANGELOG.md with a link to this PR or Issue
- [ ] I updated the README.md
- [x] I Added unit test(s)

-------------------------------------------------------------------------------------------------

<!-- Add a `- fix #_NUMBER_` line for every Issue this PR solves. Do not comma separate them -->
- fix #000
