### PR TITLE
fix(warning): Supress warnings when importing experimental web stream from NodeJS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 (Unreleased)
 ==================
 ### Removed
-- 
+-
 ### Changed
-- 
+-
 ### Added
 -
 ### Fixed
@@ -19,6 +19,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - File name are now casted to string [#109]
 - Slicing in the middle of multiple parts added more bytes than what what it should have [#109]
 - Prefixed `stream/web` import with `node:` to allow easier static analysis detection of Node built-ins [#122]
+- Added `node:` prefix in `from.js` as well [#114]
+- Suppress warning when importing `stream/web` [#114]
 
 ## v3.1.2
 
@@ -102,3 +104,4 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 [#108]: https://github.com/node-fetch/fetch-blob/pull/108
 [#109]: https://github.com/node-fetch/fetch-blob/pull/109
+[#114]: https://github.com/node-fetch/fetch-blob/pull/114

--- a/from.js
+++ b/from.js
@@ -1,6 +1,6 @@
-import {statSync, createReadStream, promises as fs} from 'fs';
-import {basename} from 'path';
-import {MessageChannel} from 'worker_threads';
+import {statSync, createReadStream, promises as fs} from 'node:fs';
+import {basename} from 'node:path';
+import {MessageChannel} from 'node:worker_threads';
 
 import File from './file.js';
 import Blob from './index.js';

--- a/streams.cjs
+++ b/streams.cjs
@@ -1,51 +1,51 @@
 /* c8 ignore start */
 // 64 KiB (same size chrome slice theirs blob into Uint8array's)
-const POOL_SIZE = 65536;
+const POOL_SIZE = 65536
 
 if (!globalThis.ReadableStream) {
-	// `node:stream/web` got introduced in v16.5.0 as experimental
-	// and it's preferred over the polyfilled version. So we also
-	// suppress the warning that gets emitted by NodeJS for using it.
-	try {
-		const process = require('node:process')
-		const { emitWarning } = process
-		try {
-			process.emitWarning = () => {}
-			Object.assign(globalThis, require('node:stream/web'))
-			process.emitWarning = emitWarning
-		} catch (error) {
-			process.emitWarning = emitWarning
-			throw error
-		}
-	} catch (error) {
-		// fallback to polyfill implementation
+  // `node:stream/web` got introduced in v16.5.0 as experimental
+  // and it's preferred over the polyfilled version. So we also
+  // suppress the warning that gets emitted by NodeJS for using it.
+  try {
+    const process = require('node:process')
+    const { emitWarning } = process
+    try {
+      process.emitWarning = () => {}
+      Object.assign(globalThis, require('node:stream/web'))
+      process.emitWarning = emitWarning
+    } catch (error) {
+      process.emitWarning = emitWarning
+      throw error
+    }
+  } catch (error) {
+    // fallback to polyfill implementation
     Object.assign(globalThis, require('web-streams-polyfill/dist/ponyfill.es2018.js'))
   }
 }
 
 try {
-	// Don't use node: prefix for this, require+node: is not supported until node v14.14
-	// Only `import()` can use prefix in 12.20 and later
+  // Don't use node: prefix for this, require+node: is not supported until node v14.14
+  // Only `import()` can use prefix in 12.20 and later
   const { Blob } = require('buffer')
   if (Blob && !Blob.prototype.stream) {
-		Blob.prototype.stream = function name(params) {
-			let position = 0;
-			const blob = this;
+    Blob.prototype.stream = function name (params) {
+      let position = 0
+      const blob = this
 
-			return new ReadableStream({
-				type: 'bytes',
-				async pull(ctrl) {
-					const chunk = blob.slice(position, Math.min(blob.size, position + POOL_SIZE));
-					const buffer = await chunk.arrayBuffer();
-					position += buffer.byteLength;
-					ctrl.enqueue(new Uint8Array(buffer))
+      return new ReadableStream({
+        type: 'bytes',
+        async pull (ctrl) {
+          const chunk = blob.slice(position, Math.min(blob.size, position + POOL_SIZE))
+          const buffer = await chunk.arrayBuffer()
+          position += buffer.byteLength
+          ctrl.enqueue(new Uint8Array(buffer))
 
-					if (position === blob.size) {
-						ctrl.close()
-					}
-				}
-			})
-		}
-	}
+          if (position === blob.size) {
+            ctrl.close()
+          }
+        }
+      })
+    }
+  }
 } catch (error) {}
 /* c8 ignore end */


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## The purpose of this PR is:
... To suppress the warning message when ppl include fetch-blob in their projects

## This is what had to change:
... i override `process.emitWarning` with a noop-fn. Import `web/stream` and then reassign the warning fn back to what it was

## This is what I like reviewers to know:
The test are also importing web/stream's so a warning is still emitted while developing. just running `node index.js` don't emit any warning

-------------------------------------------------------------------------------------------------

<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
- [x] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
- [x] I updated ./CHANGELOG.md with a link to this PR or Issue

-------------------------------------------------------------------------------------------------

<!-- Add a `- fix #_NUMBER_` line for every Issue this PR solves. Do not comma separate them -->
- fix #114 
