### PR TITLE
fix(from, tests): Fix behavior of BlobDataItem.slice()

### DIFF
--- a/from.js
+++ b/from.js
@@ -80,7 +80,7 @@ class BlobDataItem {
       path: this.#path,
       lastModified: this.lastModified,
       size: end - start,
-      start
+      start: this.#start + start
     })
   }
 

--- a/test.js
+++ b/test.js
@@ -211,6 +211,7 @@ test('blob part backed up by filesystem', async t => {
   const blob = blobFromSync('./LICENSE')
   t.is(await blob.slice(0, 3).text(), license.slice(0, 3))
   t.is(await blob.slice(4, 11).text(), license.slice(4, 11))
+  t.is(await blob.slice(4, 11).slice(2, 5).text(), license.slice(4, 11).slice(2, 5))
 })
 
 test('Reading after modified should fail', async t => {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## The purpose of this PR is:
To fix the behavior of BlobDataItem.slice() to not break when slicing a slice

## This is what had to change:
- Take into account the existing start position in `from.js`
- Added a test

## This is what like reviewers to know:



-------------------------------------------------------------------------------------------------

<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
- [x] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
- [ ] I updated ./CHANGELOG.md with a link to this PR or Issue
- [x] I Added unit test(s)

-------------------------------------------------------------------------------------------------

<!-- Add a `- fix #_NUMBER_` line for every Issue this PR solves. Do not comma separate them -->
- fix #128 
