### PR TITLE
fix: avoid reading files when the size is empty

### DIFF
--- a/from.js
+++ b/from.js
@@ -82,13 +82,16 @@ class BlobDataItem {
 
   async * stream () {
     const { mtimeMs } = await stat(this.#path)
+    const start = this.#start
+    const end = start + this.size - 1
+
     if (mtimeMs > this.lastModified) {
       throw new DOMException('The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.', 'NotReadableError')
     }
-    yield * createReadStream(this.#path, {
-      start: this.#start,
-      end: this.#start + this.size - 1
-    })
+
+    if (end > start) {
+      yield * createReadStream(this.#path, { start, end })
+    }
   }
 
   get [Symbol.toStringTag] () {

--- a/test/own-misc-test.js
+++ b/test/own-misc-test.js
@@ -189,6 +189,12 @@ promise_test(async () => {
   assert_equals(await (await fileFrom('./LICENSE')).text(), license.toString())
 }, 'blob part backed up by filesystem slice correctly')
 
+promise_test(async () => {
+  fs.writeFileSync('temp', '')
+  await blobFromSync('./temp').text()
+  fs.unlinkSync('./temp')
+}, 'can read empty files')
+
 test(async () => {
   const blob = blobFromSync('./LICENSE')
   await new Promise(resolve => setTimeout(resolve, 2000))


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## The purpose of this PR is:
... to fix a range error:
`"RangeError [ERR_OUT_OF_RANGE]: The value of "end" is out of range. It must be >= 0 && <= 9007199254740991. Received -1"`

## This is what had to change:
... when it wants to read less or equal to 0 bytes don't bother creating a write stream on the file and just bail early.

## This is what like reviewers to know:
...


-------------------------------------------------------------------------------------------------

<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
- [x] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
- [x] I Added unit test(s)
