### PR TITLE
feat: new way of creating temporary files backed up by fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,34 @@ console.log(blob.size) // ~4 GiB
 
 `blobFrom|blobFromSync|fileFrom|fileFromSync(path, [mimetype])`
 
+### Creating a temporary file on the disk
+(requires [FinalizationRegistry] - node v14.6)
+
+When using both `createTemporaryBlob` and `createTemporaryFile`
+then you will write data to the temporary folder in their respective OS.
+The arguments can be anything that [fsPromises.writeFile] supports. NodeJS
+v14.17.0+ also supports writing (async)Iterable streams and passing in a
+AbortSignal, so both NodeJS stream and whatwg streams are supported. When the
+file have been written it will return a Blob/File handle with a references to
+this temporary location on the disk. When you no longer have a references to
+this Blob/File anymore and it have been GC then it will automatically be deleted.
+
+This files are also unlinked upon exiting the process.
+```js
+import { createTemporaryBlob, createTemporaryFile } from 'fetch-blob/from.js'
+
+const req = new Request('https://httpbin.org/image/png')
+const res = await fetch(req)
+const type = res.headers.get('content-type')
+const signal = req.signal
+let blob = await createTemporaryBlob(res.body, { type, signal })
+// const file = createTemporaryBlob(res.body, 'img.png', { type, signal })
+blob = undefined // loosing references will delete the file from disk
+```
+
+`createTemporaryBlob(data, { type, signal })`
+`createTemporaryFile(data, FileName, { type, signal, lastModified })`
+
 ### Creating Blobs backed up by other async sources
 Our Blob & File class are more generic then any other polyfills in the way that it can accept any blob look-a-like item
 An example of this is that our blob implementation can be constructed with parts coming from [BlobDataItem](https://github.com/node-fetch/fetch-blob/blob/8ef89adad40d255a3bbd55cf38b88597c1cd5480/from.js#L32) (aka a filepath) or from [buffer.Blob](https://nodejs.org/api/buffer.html#buffer_new_buffer_blob_sources_options), It dose not have to implement all the methods - just enough that it can be read/understood by our Blob implementation. The minium requirements is that it has `Symbol.toStringTag`, `size`, `slice()` and either a `stream()` or a `arrayBuffer()` method. If you then wrap it in our Blob or File `new Blob([blobDataItem])` then you get all of the other methods that should be implemented in a blob or file
@@ -104,3 +132,5 @@ See the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Blo
 [install-size-image]: https://flat.badgen.net/packagephobia/install/fetch-blob
 [install-size-url]: https://packagephobia.now.sh/result?p=fetch-blob
 [fs-blobs]: https://github.com/nodejs/node/issues/37340
+[fsPromises.writeFile]: https://nodejs.org/dist/latest-v18.x/docs/api/fs.html#fspromiseswritefilefile-data-options
+[FinalizationRegistry]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry

--- a/from.js
+++ b/from.js
@@ -63,11 +63,11 @@ const fromFile = (stat, path, type = '') => new File([new BlobDataItem({
  * NOTE: requires node.js v14 or higher to use FinalizationRegistry
  *
  * @param {*} data Same as fs.writeFile data
- * @param {string} [type] mimetype to use
+ * @param {BlobPropertyBag & {signal?: AbortSignal}} options
  * @param {AbortSignal} [signal] in case you wish to cancel the write operation
  * @returns {Promise<Blob>}
  */
-const createTemporaryBlob = async (data, type, signal) => {
+const createTemporaryBlob = async (data, {signal, type} = {}) => {
   registry = registry || new FinalizationRegistry(fs.unlink)
   tempDir = tempDir || await mkdtemp(realpathSync(tmpdir()) + sep)
   const id = `${i++}`

--- a/from.js
+++ b/from.js
@@ -1,11 +1,20 @@
-import { statSync, createReadStream, promises as fs } from 'node:fs'
-import { basename } from 'node:path'
+import {
+  realpathSync,
+  statSync,
+  rmdirSync,
+  createReadStream,
+  promises as fs
+} from 'node:fs'
+import { basename, sep, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import process from 'node:process'
 import DOMException from 'node-domexception'
 
 import File from './file.js'
 import Blob from './index.js'
 
-const { stat } = fs
+const { stat, mkdtemp } = fs
+let i = 0, tempDir, registry
 
 /**
  * @param {string} path filepath on the disk
@@ -48,6 +57,42 @@ const fromFile = (stat, path, type = '') => new File([new BlobDataItem({
   lastModified: stat.mtimeMs,
   start: 0
 })], basename(path), { type, lastModified: stat.mtimeMs })
+
+/**
+ * Creates a temporary blob backed by the filesystem.
+ * NOTE: requires node.js v14 or higher to use FinalizationRegistry
+ *
+ * @param {*} data Same as fs.writeFile data
+ * @param {string} [type] mimetype to use
+ * @param {AbortSignal} [signal] in case you wish to cancel the write operation
+ * @returns {Promise<Blob>}
+ */
+const createTemporaryBlob = async (data, type, signal) => {
+  registry = registry || new FinalizationRegistry(fs.unlink)
+  tempDir = tempDir || await mkdtemp(realpathSync(tmpdir()) + sep)
+  const id = `${i++}`
+  const destination = join(tempDir, id)
+  if (data instanceof ArrayBuffer) data = new Uint8Array(data)
+  await fs.writeFile(destination, data, { signal })
+  const blob = await blobFrom(destination, type)
+  registry.register(blob, destination)
+  return blob
+}
+
+/**
+ * Creates a temporary File backed by the filesystem.
+ * Pretty much the same as constructing a new File(data, name, options)
+ *
+ * NOTE: requires node.js v14 or higher to use FinalizationRegistry
+ * @param {*} data
+ * @param {string} name
+ * @param {FilePropertyBag & {signal?: AbortSignal}} opts
+ * @returns {Promise<File>}
+ */
+const createTemporaryFile = async (data, name, opts) => {
+  const blob = await createTemporaryBlob(data)
+  return new File([blob], name, opts)
+}
 
 /**
  * This is a blob backed up by a file on the disk
@@ -102,5 +147,18 @@ class BlobDataItem {
   }
 }
 
+process.once('exit', () => {
+  tempDir && rmdirSync(tempDir, { recursive: true })
+})
+
 export default blobFromSync
-export { File, Blob, blobFrom, blobFromSync, fileFrom, fileFromSync }
+export {
+  Blob,
+  blobFrom,
+  blobFromSync,
+  createTemporaryBlob,
+  File,
+  fileFrom,
+  fileFromSync,
+  createTemporaryFile
+}

--- a/test/own-misc-test.js
+++ b/test/own-misc-test.js
@@ -215,7 +215,7 @@ promise_test(async () => {
   assert_equals(await blob.text(), license.toString())
 
   // Can specify a mime type
-  blob = await createTemporaryBlob('abc', 'text/plain')
+  blob = await createTemporaryBlob('abc', { type: 'text/plain' })
   assert_equals(blob.type, 'text/plain')
 
   // Can create files too


### PR DESCRIPTION
<!-- Thanks for contributing! -->

One thing I have been thinking of in node-fetch when we are parsing large multipart payloads with `response.formData()` is for the possibility to write dose temporary large file to the filesystem in order to not blow up the memory.

But writing them to a place on the disk would also require cleaning it up.
That's why I have now also introduced the new `createTemporaryBlob` and `createTemporaryFile` that writes whatever `fsPromise.writeFile(data)` supports

## The purpose of this PR is:
Creating new temporary files to offload some data to the filesystem and cleaning when it's garbage collected

## This is what had to change:
I exported two new features `createTemporaryBlob` and `createTemporaryFile` in `./from.js`

## This is what like reviewers to know:
- Removing / Cleaning up those temporary Blob also depends on the newish [FinalizationRegistry](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry). When a blob is `GC` and you no longer have any references to that blob anymore, then the file will automatically be removed.
- I have just learned that `fsPromise.writeFile(stream)` is more superior to `stream.pipe(fs.createWritableStream(path))` as `fsPromises. writeFile ` supports more different type of data. It works with `string, ArrayBufferView` and `(async)Iterator` so it supports both whatwg streams and node streams (from v15.14.0, v14.18.0) 
  - so i'm going to stop using `fs.createWritableStream` in all my projects... + it can tell when it's finish with a promise.


-------------------------------------------------------------------------------------------------

<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
- [ ] I updated ./CHANGELOG.md with a link to this PR or Issue ( TODO )
- [ ] I updated the README.md ( TODO )
- [x] I Added unit test(s)

